### PR TITLE
ADD: KDE Connect & Connections config locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ systemsettingsrc`
 
 * Panel
   * .config/plasma-org.kde.plasma.desktop-appletsrc
-  
+
 ---
 #### Appearance
    * Look and Feel
@@ -109,6 +109,7 @@ systemsettingsrc`
          * .config/kdeglobals
 #### Network
    * Connections
+      * /etc/NetworkManager/system-connections
    * Settings
    * Bluetooth
 #### Hardware
@@ -128,6 +129,7 @@ systemsettingsrc`
       * Energy Saving
          * ./config/powermanagementprofilesrc
    * KDE Connect
+      * ./config/kdeconnect
    * Removable Storage
 
 ## Screen Edges
@@ -152,8 +154,3 @@ ElectricBorderMaximize: Boolean
 Tiling
 
 ElectricBorderTiling: Boolean
-
-
-
-
-


### PR DESCRIPTION
First of all, thank you for creating this useful repo.
I've added 2 more config locations.

### KDE Connect
KDE Connect configs are in `./config/kde-connect` folder.
It consists of:
- trusted-devices -> list of know devices
- <random-hash> folder -> config for that specific device
- *.pem -> security keys

### Connections
KDE uses NetworkManager to manage internet connections.
Config files for all connections are stored in `/etc/NetworkManager/system-connections`.

@shalva97 Hopefully, this helps :)